### PR TITLE
fix: Replace vertexCount with indexCount in DrawElements

### DIFF
--- a/Influence.Core/BufferObject/BufferObject.cs
+++ b/Influence.Core/BufferObject/BufferObject.cs
@@ -91,8 +91,8 @@ namespace Influence
             VertexAttribPointer(index, (size / sizeof(float)), normalized, stride);
         }
 
-        /// <summary>Draws primitives from array data.</summary>
-        /// <param name="vertexCount">Number of vertices to render.</param>
+        /// <summary>Draws primitives from element data.</summary>
+        /// <param name="indexCount">Number of indices to render.</param>
         public unsafe void DrawElements(uint indexCount)
         {
             OpenGL.DrawElements(PrimitiveType.Triangles, indexCount, DrawElementsType.UnsignedInt, null);

--- a/Influence.Core/BufferObject/BufferObject.cs
+++ b/Influence.Core/BufferObject/BufferObject.cs
@@ -93,9 +93,9 @@ namespace Influence
 
         /// <summary>Draws primitives from array data.</summary>
         /// <param name="vertexCount">Number of vertices to render.</param>
-        public unsafe void DrawElements(uint vertexCount)
+        public unsafe void DrawElements(uint indexCount)
         {
-            OpenGL.DrawElements(PrimitiveType.Triangles, vertexCount, DrawElementsType.UnsignedInt, null);
+            OpenGL.DrawElements(PrimitiveType.Triangles, indexCount, DrawElementsType.UnsignedInt, null);
         }
     }
 }

--- a/Influence.Graphics/Components/Mesh.cs
+++ b/Influence.Graphics/Components/Mesh.cs
@@ -59,7 +59,7 @@ public class Mesh : Component, IRenderable
         _material.SetVector3("viewPos", Camera.mainCamera.transform.position);
 
         bufferObject.Bind();
-        bufferObject.DrawElements(vertexCount);
+        bufferObject.DrawElements(indexCount);
 
         bufferObject.Unbind();
     }


### PR DESCRIPTION
Refactored the DrawElements function to use indexCount instead of vertexCount for drawing operations. This change ensures that the correct number of indices is used for indexed drawing, which aligns with the intended usage of DrawElements. Using vertexCount was causing incorrect rendering results due to mismatched element counts.

![image](https://github.com/Influence-Engine/Influence/assets/50849877/f70e421c-0f30-4f48-91ff-599cae641445)

![image](https://github.com/Influence-Engine/Influence/assets/50849877/dc3e1d87-ca26-4139-b0f8-986f8502fdfc)
